### PR TITLE
trying to fix #4 - Too many publishes

### DIFF
--- a/endpoint/cloudio-endpoint-java/build.gradle
+++ b/endpoint/cloudio-endpoint-java/build.gradle
@@ -17,7 +17,7 @@ repositories {
 
 dependencies {
     compile 'com.fasterxml.jackson.core:jackson-core:2.6.4'
-    compile 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.0.2'
+    compile 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.0'
     compile 'org.slf4j:slf4j-api:1.7.13'
     testCompile 'junit:junit:4.12'
 }

--- a/endpoint/cloudio-endpoint-java/src/main/java/ch/hevs/cloudio/endpoint/CloudioEndpoint.java
+++ b/endpoint/cloudio-endpoint-java/src/main/java/ch/hevs/cloudio/endpoint/CloudioEndpoint.java
@@ -520,8 +520,8 @@ public class CloudioEndpoint implements CloudioEndpointService {
                 options.setMaxInflight(Integer.parseInt(
                     configuration.getProperty(MQTT_MAXINFLIGHT_PROPERTY, MQTT_MAXINFLIGHT_DEFAULT)));
             } catch (NumberFormatException exception) {
-                throw new InvalidPropertyException("Invalid keep alive interval " +
-                        "(ch.hevs.cloudio.endpoint.keepAliveInterval), " +
+                throw new InvalidPropertyException("Invalid max in flight messages" +
+                        "(ch.hevs.cloudio.endpoint.maxInFlight), " +
                         "must be a valid integer number");
             }
 

--- a/endpoint/cloudio-endpoint-java/src/main/java/ch/hevs/cloudio/endpoint/CloudioEndpoint.java
+++ b/endpoint/cloudio-endpoint-java/src/main/java/ch/hevs/cloudio/endpoint/CloudioEndpoint.java
@@ -378,6 +378,8 @@ public class CloudioEndpoint implements CloudioEndpointService {
         private static final String MQTT_CONNECT_RETRY_DEFAULT      = "10";
         private static final String MQTT_KEEPALIVE_INTERVAL_PROPERTY= "ch.hevs.cloudio.endpoint.keepAliveInterval";
         private static final String MQTT_KEEPALIVE_INTERVAL_DEFAULT = "60";
+        private static final String MQTT_MAXINFLIGHT_PROPERTY		= "ch.hevs.cloudio.endpoint.maxInFlight";
+        private static final String MQTT_MAXINFLIGHT_DEFAULT		= "1000";
         private static final String MQTT_PERSISTENCE_MEMORY         = "memory";
         private static final String MQTT_PERSISTENCE_FILE           = "file";
         private static final String MQTT_PERSISTENCE_NONE           = "none";
@@ -512,6 +514,16 @@ public class CloudioEndpoint implements CloudioEndpointService {
                         "(ch.hevs.cloudio.endpoint.keepAliveInterval), " +
                         "must be a valid integer number");
             }
+            
+            // Get the maxInFlight property.
+            try {
+                options.setMaxInflight(Integer.parseInt(
+                    configuration.getProperty(MQTT_MAXINFLIGHT_PROPERTY, MQTT_MAXINFLIGHT_DEFAULT)));
+            } catch (NumberFormatException exception) {
+                throw new InvalidPropertyException("Invalid keep alive interval " +
+                        "(ch.hevs.cloudio.endpoint.keepAliveInterval), " +
+                        "must be a valid integer number");
+            }
 
             // Create persistence object.
             String persistenceProvider = configuration.getProperty(MQTT_PERSISTENCE_PROPERTY, MQTT_PERSISTENCE_DEFAULT);
@@ -529,6 +541,7 @@ public class CloudioEndpoint implements CloudioEndpointService {
 
             // Last will is a message with the UUID of the endpoint and no payload.
             options.setWill("@offline/" + uuid, new byte[0], 1, false);
+
 
             // Create the MQTT client.
             try {


### PR DESCRIPTION
It seems that we have some problems when trying to publish too many messages,
paho v1.2 has introduced setMaxInflight, so let's use it.

* Updated to org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.0
* Added the ch.hevs.cloudio.endpoint.maxInFlight property (default to 1000 instead of 10 in paho)